### PR TITLE
`arm64: dts: rockchip: working pci3x4 for Mixtile Blade3`

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3588-mixtile-blade3.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588-mixtile-blade3.dts
@@ -252,6 +252,7 @@
 	status = "okay";
 };
 
+/* exposed on the 30-pin connector; shows up as i2c-3 */
 &i2c5 {
 	pinctrl-0 = <&i2c5m3_xfer>;
 	status = "okay";
@@ -282,7 +283,7 @@
 };
 
 &pcie30phy {
-    status = "okay";
+	status = "okay";
 };
 
 &pcie3x4 {
@@ -317,12 +318,6 @@
 
 		pcie3_vcc3v3_en: pcie3-vcc3v3-en {
 			rockchip,pins = <1 RK_PB2 RK_FUNC_GPIO &pcfg_pull_none>;
-		};
-	};
-
-	hym8563 {
-		hym8563_int: hym8563-int {
-			rockchip,pins = <0 RK_PB0 RK_FUNC_GPIO &pcfg_pull_up>;
 		};
 	};
 };

--- a/arch/arm64/boot/dts/rockchip/rk3588-mixtile-blade3.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588-mixtile-blade3.dts
@@ -105,6 +105,8 @@
 		regulator-min-microvolt = <3300000>;
 		regulator-max-microvolt = <3300000>;
 		enable-active-high;
+		regulator-boot-on;
+		regulator-always-on;
 		gpios = <&gpio1 RK_PB2 GPIO_ACTIVE_HIGH>;
 		startup-delay-us = <5000>;
 		vin-supply = <&vcc12v_dcin>;
@@ -317,7 +319,7 @@
 		};
 
 		pcie3_vcc3v3_en: pcie3-vcc3v3-en {
-			rockchip,pins = <1 RK_PB2 RK_FUNC_GPIO &pcfg_pull_none>;
+			rockchip,pins = <1 RK_PB2 RK_FUNC_GPIO &pcfg_pull_up>;
 		};
 	};
 };


### PR DESCRIPTION
Hey @Joshua-Riek -- I tried your DT for the blade3, almost everything worked (thank you!), except `pcie3x4`. 

I got it going with the subtlety of a hammer; pull the pin up and make the regulator always-on. I'm not happy with `regulator-always-on` (none of the other mainline boards have it), but I couldn't get it going otherwise. 

Also a small cleanup, since I don't think we have an RTC on the blade3.

`dmesg`: https://paste.next.armbian.com/itesibokeb (I've a sata2 overlay enabled in this)
